### PR TITLE
Fix next and back buttons being out of screen

### DIFF
--- a/app/src/components/multistepform.js
+++ b/app/src/components/multistepform.js
@@ -30,7 +30,7 @@ export default function MultiStepForm({children, submitText, handleSubmit, showN
   }
 
   return (
-    <div className="flex h-screen rounded-lg border border-gray-300 h-fit min-h-96 relative p-4">
+    <div className="flex h-[80vh] rounded-lg border border-gray-300 h-fit min-h-96 relative p-4">
       <div className="md:flex flex-col w-56">
         {
           Children.map(children, (child, idx) => {


### PR DESCRIPTION
I set the height of the multistepform to be only 80% of the viewport so that the back and next buttons are no longer off screen. 

Closes #37

![Screenshot (22)](https://github.com/J-Raymer/printlink3d/assets/57274383/b974ee3c-5a47-41b5-a4a2-d467254ae336)
