### PR TITLE
Add: home button over logo & some padding on configure page

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -1,4 +1,4 @@
-import { Routes, Route, Outlet } from "react-router-dom";
+import { Routes, Route, Outlet, useNavigate } from "react-router-dom";
 
 import './app.css';
 import Home from './routes/home.js';
@@ -7,10 +7,13 @@ import Browse from './routes/browse.js';
 
 
 function Layout() {
+  const navigate = useNavigate();
   return (
     <div className="container mx-auto">
       <nav className="p-4">
-        <h2 className="text-xl font-bold">PrintLink3D</h2>
+        <button className="bg-transparent rounded-lg px-4 py-2" onClick={() => navigate('/')}>
+          <h2 className="text-xl font-bold">PrintLink3D</h2>
+        </button>        
       </nav>
       <Outlet />
     </div>

--- a/app/src/routes/configure.js
+++ b/app/src/routes/configure.js
@@ -42,7 +42,7 @@ export default function Configure({printJob, onChange}) {
   const changeName = (x) => onChange(x.target.value, "name");
   
   return (
-    <div>
+    <div className="pb-10">
       <div className="p-5">
         <div className="my-4">
           <h2 className="text-3xl font-semibold text-gray-800"> Print Parameters </h2>


### PR DESCRIPTION
Clicking the logo in the top right routes back to home page now & added some padding between the content and navigation buttons on the configure page.