### PR TITLE
Update README.md for local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,13 @@ The My Jobs Page is the other end of the My Orders page. Here Printers can view 
 If using Ubuntu or WSL2 you can install node via: [Nodesource](https://deb.nodesource.com/)
 
 ## Setup
-Execute the following to setup your environment:
+Execute the following in the /printlink3d directory to setup your environment:
 ```
-cd app
 npm install
 ```
 
 ## Running
-To start the local dev server execute in the /app directory:
+Execute the following in the /printlink3d directory to start the local dev server:
 ```
 npm start
 ```


### PR DESCRIPTION
Just tried to setup the npm stuff after freshly cloning the repository and it didn't work. The old instructions had you do everything in the /app directory, but now package.json is no longer found there so I removed the instruction that told you to be in /app. Let me know if this is incorrect, it is just what worked for me, and it should be figured out for if the graders want to run the code locally