### PR TITLE
Shorten file name in upload page if too long

### DIFF
--- a/src/routes/upload.js
+++ b/src/routes/upload.js
@@ -135,6 +135,13 @@ export default function Upload({ printJob, updateFile, updateThumbnail }) {
     );
   }
 
+  function shortenFileName(fileName, length) {
+    if (fileName.length <= length) {
+      return fileName;
+    }
+    return fileName.substring(0, length) + "...";
+  }
+
   function captureThumbnail() {
     const croppedDimenstions = 200;
     renderer.setSize(croppedDimenstions, croppedDimenstions);
@@ -201,7 +208,7 @@ export default function Upload({ printJob, updateFile, updateThumbnail }) {
           :
           <div className="flex flex-col h-full">
             <div className="flex w-full items-center mt-3 justify-between">
-              <p className="text-4xl font-bold">Selected: {printJob.file.name}</p>
+              <p className="text-4xl font-bold">Selected: {shortenFileName(printJob.file.name, 35)}</p>
               <p onClick={() => removeSTL()} className="text-4xl text-blue-500 cursor-pointer underline">Change File</p>
             </div>
             <div className="flex flex-col items-center justify-center full-without-title mt-4 grow" id="canvas-rect">


### PR DESCRIPTION
Shortens the displayed name of the file if it's too lonfg. This was causing an issue where the 3D viewer would stretch horiztonally

Closes #124 

### **Before**

![Screenshot (56)](https://github.com/J-Raymer/printlink3d/assets/57274383/cc1329db-c5b5-43bb-afae-744c5ab23f29)


### **After**

![Screenshot (57)](https://github.com/J-Raymer/printlink3d/assets/57274383/9f76b7c4-69b7-40f0-97a2-2be4f1f04b1d)
