### PR TITLE
Removes File Name From Job Parameters

### DIFF
--- a/src/routes/browse.js
+++ b/src/routes/browse.js
@@ -346,7 +346,11 @@ export default function Browse() {
 
                   <table className="browse-table text-l mt-3">
                     <tr>
-                      <td className="w-[160px]">Infill:</td>
+                      <td className="w-[160px]">Job Name: </td>
+                      <td>{selectedJob.jobName}</td>
+                    </tr>
+                    <tr>
+                      <td>Infill:</td>
                       <td>{selectedJob.infill}</td>
                     </tr>
                     <tr>

--- a/src/routes/browse.js
+++ b/src/routes/browse.js
@@ -346,11 +346,7 @@ export default function Browse() {
 
                   <table className="browse-table text-l mt-3">
                     <tr>
-                      <td className="w-[160px]">File Name: </td>
-                      <td>{selectedJob.fileName}</td>
-                    </tr>
-                    <tr>
-                      <td>Infill:</td>
+                      <td className="w-[160px]">Infill:</td>
                       <td>{selectedJob.infill}</td>
                     </tr>
                     <tr>


### PR DESCRIPTION
fileName is no longer needed since there is the job name field.